### PR TITLE
Add --year option for resolving duplicate series names

### DIFF
--- a/episoderenamer.py
+++ b/episoderenamer.py
@@ -64,9 +64,9 @@ def parse_imdbapi(show_id, options):
 
     url = 'http://imdbapi.poromenos.org/json/?name=%s' % urllib.quote(show_id)
     if options.year:
-        url += '&year=%s' % options.year
+        url += '&year=%s' % urllib.quote(options.year)
     results = json.loads(urllib2.urlopen(url).read())
-    if results is None:
+    if not results:
         print "Show not found."
         sys.exit()
     elif 'shows' in results:


### PR DESCRIPTION
I added a -y/--year option and some additional output for resolving shows with duplicate names.  When multiple shows are returned from imdbapi, a list of their corresponding years are presented with a hint to specify the --year option to resolve the ambiguity.
